### PR TITLE
[Feat] 플레이어 공격 및 대쉬 진행 시의 방향 설정  

### DIFF
--- a/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
+++ b/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
@@ -2389,7 +2389,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c3f412b3fcd07947887854a365bd75c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  IsAutoLockOn: 0
+  target: {fileID: 0}
   lookAt: {fileID: 813043441}
+  sensitivity: 3
   delta: {x: 0, y: 0.5, z: -3.5}
 --- !u!1 &2114479522
 GameObject:

--- a/Assets/Workers/DEV/YSH/Scripts/Camera/CameraController.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/Camera/CameraController.cs
@@ -44,12 +44,12 @@ public class CameraController : MonoBehaviour
     {
         if (IsAutoLockOn == false)
         {
-            //yAngle += Input.GetAxisRaw("Mouse X") * 2f;
-            //transform.rotation = Quaternion.Euler(0, yAngle, 0);
+            yAngle += Input.GetAxisRaw("Mouse X") * sensitivity;
+            transform.rotation = Quaternion.Euler(0, yAngle, 0);
 
-            yAngle += Input.GetAxisRaw("Mouse X");
-            Vector3 dir = lookAt.position - transform.position;
-            transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(0, yAngle, 0), sensitivity * Time.deltaTime);
+            //yAngle += Input.GetAxisRaw("Mouse X");
+            //Vector3 dir = lookAt.position - transform.position;
+            //transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(0, yAngle, 0), sensitivity * Time.deltaTime);
         }
         else
         {

--- a/Assets/Workers/DEV/YSH/Scripts/Effect/IEffect.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/Effect/IEffect.cs
@@ -2,6 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// 각 Effect가 구현해야 하는 인터페이스
+/// </summary>
 public interface IEffect
 {
     void Activate(GameObject attacker, GameObject target);

--- a/Assets/Workers/DEV/YSH/Scripts/Effect/IKnockBack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/Effect/IKnockBack.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// KnockBack 이펙트를 구현하기 위한 인터페이스
+/// 해당 인터페이스를 상속받아 실제 동작을 구현
+/// </summary>
 public interface IKnockBack
 {
     void KnockBack(GameObject attacker);

--- a/Assets/Workers/DEV/YSH/Scripts/Effect/KnockBack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/Effect/KnockBack.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// KnockBack 이펙트 클래스
+/// IKnockBack을 구현한 객체로부터 KnockBack을 호출한다.
+/// </summary>
 public class KnockBack : IEffect
 {
     public void Activate(GameObject attacker, GameObject target)

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -232,9 +232,8 @@ public class PlayerAttack : MonoBehaviour
         }
         else
         {
-            List<MultiActionInfo> actionList = multiActions.ToList();
             // 현재 Action과 일치하는 MultiActionInfo를 가져온다 (Where)
-            currentAction = actionList.Where(x => x.ActionType == ActionType).First();
+            currentAction = multiActions.Where(x => x.ActionType == ActionType).First();
             AddMultiActionEffects(tobj, currentAction);
 
             // 수치 저장

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerMovement.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerMovement.cs
@@ -16,6 +16,8 @@ public class PlayerMovement : MonoBehaviour
 
     private Transform mainCamTrf;
 
+    public Rigidbody Rigid => rigid;
+
     private void Awake()
     {
         rigid = GetComponent<Rigidbody>();
@@ -36,6 +38,11 @@ public class PlayerMovement : MonoBehaviour
         // 현재 카메라 방향을 기준으로 이동을 진행한다.
         Vector3 velocity = (mainCamTrf.right * moveVelocity.x) + (mainCamTrf.forward * moveVelocity.z);
         rigid.velocity = new Vector3(velocity.x + moveDir.x, rigid.velocity.y, velocity.z + moveDir.z);
+
+        // 원본 코드 백업
+        // 현재 카메라 방향을 기준으로 이동을 진행한다.
+        //Vector3 velocity = (mainCamTrf.right * moveVelocity.x) + (mainCamTrf.forward * moveVelocity.z);
+        //rigid.velocity = new Vector3(velocity.x, rigid.velocity.y, velocity.z);
 
         if (velocity != Vector3.zero)
         {

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerMovement.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerMovement.cs
@@ -37,12 +37,7 @@ public class PlayerMovement : MonoBehaviour
 
         // 현재 카메라 방향을 기준으로 이동을 진행한다.
         Vector3 velocity = (mainCamTrf.right * moveVelocity.x) + (mainCamTrf.forward * moveVelocity.z);
-        rigid.velocity = new Vector3(velocity.x + moveDir.x, rigid.velocity.y, velocity.z + moveDir.z);
-
-        // 원본 코드 백업
-        // 현재 카메라 방향을 기준으로 이동을 진행한다.
-        //Vector3 velocity = (mainCamTrf.right * moveVelocity.x) + (mainCamTrf.forward * moveVelocity.z);
-        //rigid.velocity = new Vector3(velocity.x, rigid.velocity.y, velocity.z);
+        rigid.velocity = new Vector3(velocity.x, rigid.velocity.y, velocity.z);
 
         if (velocity != Vector3.zero)
         {

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/DashState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/DashState.cs
@@ -5,10 +5,11 @@ using UnityEngine;
 public class DashState : BaseState<PlayerController>
 {
     private Vector3 moveDir;
-    private Vector3 velocity;
 
     private float dashTimer;
     private Transform camTrf;
+
+    Vector3 lookDir;
 
     public DashState(PlayerController owner)
     {
@@ -31,14 +32,16 @@ public class DashState : BaseState<PlayerController>
         // 방향키 입력이 있는 경우 카메라 정면을 기준으로 입력한 방향을 바라본다.
         if (moveDir != Vector3.zero)
         {
-            owner.Movement.LookAt(moveDir);
+            owner.Movement.LookAt((camTrf.right * moveDir.x) + (camTrf.forward * moveDir.z));
         }
         // 방향키 입력이 없는 경우 카메라 정면을 바라본다.
         else
         {
-            moveDir = Vector3.forward;
             owner.Movement.LookAt(camTrf.forward);
         }
+
+        // 대쉬 진행시작 방향을 기억한다.
+        lookDir = owner.transform.forward;
 
         owner.Anim.CrossFade(Define.HASH_ANIM_DASH, 0.1f);
     }
@@ -46,6 +49,13 @@ public class DashState : BaseState<PlayerController>
     public override void OnUpdate()
     {
         base.OnUpdate();
+
+        // 회전이 원복되는 현상 방지 (Adjust)
+        if (lookDir != Vector3.zero && owner.transform.forward != lookDir)
+        {
+            Debug.Log("<color=red>Adjust forward</color>");
+            owner.Movement.LookAt(lookDir);
+        }
 
         dashTimer -= Time.deltaTime;
 
@@ -55,8 +65,9 @@ public class DashState : BaseState<PlayerController>
             return;
         }
 
-        // 지정된 방향으로 대쉬 진행
-        owner.Movement.Move(moveDir * owner.Stat.DashSpeed);
+        // 대쉬의 경우 진행중 카메라 방향의 영향을 받지 않아야 하므로 Move 함수 사용 없이 velocity만 변경
+        // 기억해뒀던 방향 (lookDir) 으로 진행
+        owner.Movement.Rigid.velocity = lookDir * owner.Stat.DashSpeed;
     }
 
     public override void OnExit()

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/DashState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/DashState.cs
@@ -25,8 +25,21 @@ public class DashState : BaseState<PlayerController>
 
         dashTimer = owner.Stat.DashTime;
 
-        // 카메라 정면을 바라본다.
-        owner.Movement.LookAt(camTrf.forward);
+        // 대쉬 시 입력값이 있는지 확인하기 위해 저장
+        moveDir = owner.PInput.InputDir.normalized;
+
+        // 방향키 입력이 있는 경우 카메라 정면을 기준으로 입력한 방향을 바라본다.
+        if (moveDir != Vector3.zero)
+        {
+            owner.Movement.LookAt(moveDir);
+        }
+        // 방향키 입력이 없는 경우 카메라 정면을 바라본다.
+        else
+        {
+            moveDir = Vector3.forward;
+            owner.Movement.LookAt(camTrf.forward);
+        }
+
         owner.Anim.CrossFade(Define.HASH_ANIM_DASH, 0.1f);
     }
 
@@ -42,7 +55,8 @@ public class DashState : BaseState<PlayerController>
             return;
         }
 
-        owner.Movement.Move(Vector3.forward * owner.Stat.DashSpeed);
+        // 지정된 방향으로 대쉬 진행
+        owner.Movement.Move(moveDir * owner.Stat.DashSpeed);
     }
 
     public override void OnExit()

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/DashState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/DashState.cs
@@ -9,7 +9,7 @@ public class DashState : BaseState<PlayerController>
     private float dashTimer;
     private Transform camTrf;
 
-    Vector3 lookDir;
+    private Vector3 lookDir;
 
     public DashState(PlayerController owner)
     {
@@ -53,7 +53,6 @@ public class DashState : BaseState<PlayerController>
         // 회전이 원복되는 현상 방지 (Adjust)
         if (lookDir != Vector3.zero && owner.transform.forward != lookDir)
         {
-            Debug.Log("<color=red>Adjust forward</color>");
             owner.Movement.LookAt(lookDir);
         }
 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/MeleeState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/MeleeState.cs
@@ -14,6 +14,10 @@ public class MeleeState : BaseState<PlayerController>
     // 공격전 PlayerAttack 스크립트의 Count를 저장해두는 용도
     private int meleeCount;
 
+    private Transform camTrf;
+
+    private Vector3 lookDir;
+
     public MeleeState(PlayerController owner)
     {
         this.owner = owner;
@@ -30,6 +34,9 @@ public class MeleeState : BaseState<PlayerController>
     // 근접공격 애니메이션 재생
     public override void OnEnter()
     {
+        if (camTrf == null)
+            camTrf = Camera.main.transform;
+
         // 공격을 진행하기 전의 Count를 미리 저장해둔다.
         // Update시점에는 이미 Count가 바뀌기 때문에 먼저 저장한다
         meleeCount = owner.Attack.MeleeCount;
@@ -38,6 +45,10 @@ public class MeleeState : BaseState<PlayerController>
         owner.Movement.Move(Vector3.zero);
 
         animTimer = 999;
+
+        // 카메라 정면을 바라본다.
+        lookDir = camTrf.forward;   // 공격 시전 시 바라봤던 방향을 기억해둔다.
+        owner.Movement.LookAt(lookDir);
 
         owner.Anim.CrossFade(meleeAnimHashes[owner.Attack.MeleeCount], 0.01f);
         owner.StartCoroutine(AnimRoutine());
@@ -55,9 +66,18 @@ public class MeleeState : BaseState<PlayerController>
 
     public override void OnUpdate()
     {
+        // 회전이 원복되는 현상 방지 (Adjust)
+        if (lookDir != Vector3.zero && owner.transform.forward != lookDir)
+        {
+            owner.Movement.LookAt(lookDir);
+        }
+
         // 애니메이션 재생이 완료되면 상태 종료
         if (animTimer <= 0)
         {
+            // Adjust를 중지하기 위해 lookDir을 초기화
+            lookDir = Vector3.zero;
+
             if (meleeCount >= owner.Attack.MeleeCountMax-1)
             {
                 owner.ChangeState(EState.Idle);

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
@@ -17,7 +17,7 @@ public class ThrowState : BaseState<PlayerController>
 
     private Transform camTrf;
 
-    Vector3 lookDir;
+    private Vector3 lookDir;
 
     public ThrowState(PlayerController owner)
     {
@@ -120,7 +120,6 @@ public class ThrowState : BaseState<PlayerController>
         // 애니메이션 도중 회전이 원복되는 현상 방지 (Adjust)
         if (lookDir != Vector3.zero && owner.transform.forward != lookDir)
         {
-            Debug.Log("<color=red>Adjust forward</color>");
             owner.Movement.LookAt(lookDir);
         }
 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor.Rendering.LookDev;
 using UnityEngine;
 
 public class ThrowState : BaseState<PlayerController>
@@ -15,6 +16,8 @@ public class ThrowState : BaseState<PlayerController>
     private Vector3 inputDir;
 
     private Transform camTrf;
+
+    Vector3 lookDir;
 
     public ThrowState(PlayerController owner)
     {
@@ -60,9 +63,8 @@ public class ThrowState : BaseState<PlayerController>
         animTimer = 999;
 
         // 카메라 정면을 바라본다.
-        Debug.Log($"before lookAt forward : {owner.transform.forward}");
-        owner.Movement.LookAt(camTrf.forward);
-        Debug.Log($"after lookAt forward : {owner.transform.forward}");
+        lookDir = camTrf.forward;   // 공격 시전 시 바라봤던 방향을 기억해둔다.
+        owner.Movement.LookAt(lookDir);
 
         SetAction();
 
@@ -72,7 +74,6 @@ public class ThrowState : BaseState<PlayerController>
     public override void OnExit()
     {
         base.OnExit();
-        Debug.Log($"Exit forward : {owner.transform.forward}");
     }
 
     private void SetAction()
@@ -80,19 +81,17 @@ public class ThrowState : BaseState<PlayerController>
         MultiActionInfo[] multiActions = owner.Attack.ThrowAttackInfo[throwCount].MultiActions;
         if (multiActions.Length <= 0)
         {
-            Debug.Log($"before anim forward : {owner.transform.forward}");
             owner.Anim.CrossFade(throwAnimHashes[owner.Attack.ThrowCount], 0.01f);
-            Debug.Log($"after anim forward : {owner.transform.forward}");
             return;
         }
 
         int animHash;
-        if ((int)inputDir.x > 0)
+        if (inputDir.x > 0)
         {
             animHash = throwMultiAnimHashes[throwCount, (int)EMultiActionType.Right];
             owner.Attack.ActionType = EMultiActionType.Right;
         }
-        else if ((int)inputDir.x < 0)
+        else if (inputDir.x < 0)
         {
             animHash = throwMultiAnimHashes[throwCount, (int)EMultiActionType.Left];
             owner.Attack.ActionType = EMultiActionType.Left;
@@ -103,9 +102,7 @@ public class ThrowState : BaseState<PlayerController>
             owner.Attack.ActionType = EMultiActionType.Basic;
         }
 
-        Debug.Log($"before anim forward : {owner.transform.forward}");
         owner.Anim.CrossFade(animHash, 0.01f);
-        Debug.Log($"after anim forward : {owner.transform.forward}");
     }
 
     IEnumerator AnimRoutine()
@@ -120,6 +117,13 @@ public class ThrowState : BaseState<PlayerController>
 
     public override void OnUpdate()
     {
+        // 애니메이션 도중 회전이 원복되는 현상 방지 (Adjust)
+        if (lookDir != Vector3.zero && owner.transform.forward != lookDir)
+        {
+            Debug.Log("<color=red>Adjust forward</color>");
+            owner.Movement.LookAt(lookDir);
+        }
+
         // 대쉬가 입력되면 공격을 캔슬 (점프 시에는 불가)
         // 공격 카운트도 체크하여 마지막 공격때는 캔슬안되게 해야 함
         if (owner.Movement.IsGrounded && owner.PInput.TryDash)
@@ -132,6 +136,9 @@ public class ThrowState : BaseState<PlayerController>
         // 애니메이션 재생이 완료되면 상태 종료
         if (animTimer <= 0)
         {
+            // Adjust를 중지하기 위해 lookDir을 초기화
+            lookDir = Vector3.zero;
+
             owner.Attack.ThrowCount++;
 
             // 마지막 타수였거나 물건 스택이 없는 경우 바로 Idle로 이동


### PR DESCRIPTION
- 근거리 원거리 공격 시 카메라 쪽으로 돌아보도록 구현
  - 공격 시에는 무조건 카메라 정면을 바라보도록 함
  - 애니메이션 재생 시 회전이 원복되는 현상이 있어 예외 처리 후 해결
- 대쉬 진행 시 입력 여부에 따라 방향 설정
  - 대쉬 진입 시 입력한 방향을 확인해서 방향 입력이 있었던 경우 카메라 정면 기준 입력한 방향으로 회전 후 대쉬
  - 입력한 방향이 없었던 경우 기존과 동일하게 카메라 정면으로 회전후 대쉬
- 추가 작업
  - 변경된 Move 로직에서 벡터가 여러번 더해져 속도가 빨라지는 문제가 있어 수정
  - 락온 미진행시 카메라가 러프하게 돌아가는 것을 제거하고 원복  