### PR TITLE
[Feat] 플레이어와 StatModel 연동 및 플레이어 피격 구현

### DIFF
--- a/Assets/Workers/DEV/KMG/Script/StatModel.cs
+++ b/Assets/Workers/DEV/KMG/Script/StatModel.cs
@@ -37,8 +37,8 @@ public class StatModel : MonoBehaviour
     [SerializeField] float allPowerPer;
     public float AllPowerPer { get => allPowerPer + (GetAbility(AdditionAbility.AllPowerPer)); private set { } }
     public float DefaultPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.DefaultPowerPer))) * 0.01f); private set { } }
-    public float SkillPowerPer { get => AllPowerPer + (GetAbility(AdditionAbility.SkillPowerPer)); private set { } }
-    public float ElementalPowerPer { get => AllPowerPer + (GetAbility(AdditionAbility.ElementalPowerPer)); private set { } }
+    public float SkillPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.SkillPowerPer))) * 0.01f); private set { } }
+    public float ElementalPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.ElementalPowerPer))) * 0.01f); private set { } }
     
     public float DashSpeed;
 

--- a/Assets/Workers/DEV/KMG/Script/StatModel.cs
+++ b/Assets/Workers/DEV/KMG/Script/StatModel.cs
@@ -50,6 +50,9 @@ public class StatModel : MonoBehaviour
 
     public float DashStaminaAmount;
 
+    // 스테미너가 소모되는 행동 진행 시 곱해줘야 하는 값
+    public float StaminaCostRate = 1f;
+
     [Header("실시간 능력치")]
 
     [SerializeField] float currentHp;
@@ -75,12 +78,23 @@ public class StatModel : MonoBehaviour
     [SerializeField] float currentStamina;
     public float CurrentStamina 
     { 
-        get => currentStamina; 
-        set 
+        get => currentStamina;
+        private set
         {
             currentStamina = Mathf.Clamp(value, 0, MaxStamina);
             OnCurStaminaChange?.Invoke(currentStamina);
-        } 
+        }
+    }
+
+    /// <summary>
+    /// Stamina에 더하거나 뺄 값을 넘겨준다.
+    /// </summary>
+    /// <param name="stamina"></param>
+    public void ChangeStamina(float stamina)
+    {
+        currentStamina += stamina * StaminaCostRate;
+        currentStamina = Mathf.Clamp(currentStamina, 0, maxStamina);
+        OnCurStaminaChange?.Invoke(currentStamina);
     }
 
     [SerializeField] float chip;

--- a/Assets/Workers/DEV/KMG/Script/StatModel.cs
+++ b/Assets/Workers/DEV/KMG/Script/StatModel.cs
@@ -31,6 +31,9 @@ public class StatModel : MonoBehaviour
     [SerializeField] float maxStamina;
     public float MaxStamina { get => maxStamina + (0.01f * maxStamina * GetAbility(AdditionAbility.MaxStaminaPer)); set { maxStamina = value; OnMaxStaminaChange?.Invoke(value); } }
 
+    [SerializeField] float maxMp;
+    public float MaxMp { get => maxMp; private set { } }
+
     [SerializeField] float moveSpeed;
     public float MoveSpeed { get => moveSpeed + (0.01f * moveSpeed * GetAbility(AdditionAbility.MoveSpeedPer)); set { moveSpeed = value; OnMoveSpeedChange?.Invoke(value); } }
 
@@ -50,19 +53,57 @@ public class StatModel : MonoBehaviour
     [Header("실시간 능력치")]
 
     [SerializeField] float currentHp;
-    public float CurrentHp { get => currentHp; set { currentHp = value; OnCurHpChange?.Invoke(value); } }
+    public float CurrentHp { 
+        get => currentHp; 
+        set 
+        {
+            currentHp = Mathf.Clamp(value, 0, MaxHp);
+            OnCurHpChange?.Invoke(currentHp);
+        } 
+    }
 
     [SerializeField] float currentMp;
-    public float CurrentMp { get => currentMp; set { currentMp = value; OnCurMpChange?.Invoke(value); } }
+    public float CurrentMp { 
+        get => currentMp; 
+        set 
+        {
+            currentMp = Mathf.Clamp(value, 0, maxMp);
+            OnCurMpChange?.Invoke(currentMp); 
+        } 
+    }
 
     [SerializeField] float currentStamina;
-    public float CurrentStamina { get => currentStamina; set { currentStamina = value; OnCurStaminaChange?.Invoke(value); } }
+    public float CurrentStamina 
+    { 
+        get => currentStamina; 
+        set 
+        {
+            currentStamina = Mathf.Clamp(value, 0, MaxStamina);
+            OnCurStaminaChange?.Invoke(currentStamina);
+        } 
+    }
 
     [SerializeField] float chip;
-    public float Chip { get => chip; set { chip = value; OnChipChange?.Invoke(value); } }
+    public float Chip 
+    {
+        get => chip;
+        set 
+        {
+            chip = value; 
+            OnChipChange?.Invoke(value); 
+        }
+    }
 
     [SerializeField] float blackChip;
-    public float BlackChip { get => blackChip; set { blackChip = value; OnBlackChipChange?.Invoke(value); } }
+    public float BlackChip 
+    { 
+        get => blackChip; 
+        set 
+        {
+            blackChip = value; 
+            OnBlackChipChange?.Invoke(value); 
+        } 
+    }
 
     [Header("추가 능력치")] // 아이템으로 상승하는 능력치 편의상 배열로 만들었음
     [SerializeField] float[] additionAbility = new float[(int)AdditionAbility.Size];

--- a/Assets/Workers/DEV/KMG/Script/StatModel.cs
+++ b/Assets/Workers/DEV/KMG/Script/StatModel.cs
@@ -39,10 +39,13 @@ public class StatModel : MonoBehaviour
     public float DefaultPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.DefaultPowerPer))) * 0.01f); private set { } }
     public float SkillPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.SkillPowerPer))) * 0.01f); private set { } }
     public float ElementalPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.ElementalPowerPer))) * 0.01f); private set { } }
-    
+
+    [SerializeField] float staminarEgeneration;
+    public float StaminarEgeneration { get => staminarEgeneration * (1 + ((GetAbility(AdditionAbility.StaminarEgeneration)) * 0.01f)); private set { } }
+
     public float DashSpeed;
 
-    public float DashSteminaAmount;
+    public float DashStaminaAmount;
 
     [Header("실시간 능력치")]
 

--- a/Assets/Workers/DEV/KMG/Script/UI_StatModel.cs
+++ b/Assets/Workers/DEV/KMG/Script/UI_StatModel.cs
@@ -62,7 +62,7 @@ public class UI_StatModel : MonoBehaviour
         // 얍샙이
         statModel.CurrentHp += 0;
         statModel.CurrentMp += 0;
-        statModel.CurrentStamina += 0;
+        statModel.ChangeStamina(0);
         atackPowerText.text = $"공격력: {statModel.AllPowerPer}";
     }
 }

--- a/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
+++ b/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
@@ -6528,6 +6528,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHp: 100
   maxStamina: 100
+  maxMp: 100
   moveSpeed: 5
   allPowerPer: 0
   staminarEgeneration: 10

--- a/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
+++ b/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
@@ -6529,9 +6529,10 @@ MonoBehaviour:
   maxHp: 100
   maxStamina: 100
   moveSpeed: 5
-  allPower: 0
+  allPowerPer: 0
+  staminarEgeneration: 10
   DashSpeed: 6.5
-  DashSteminaAmount: 100
+  DashStaminaAmount: 0
   currentHp: 100
   currentMp: 0
   currentStamina: 100

--- a/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
+++ b/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
@@ -6534,6 +6534,7 @@ MonoBehaviour:
   staminarEgeneration: 10
   DashSpeed: 6.5
   DashStaminaAmount: 0
+  StaminaCostRate: 0
   currentHp: 100
   currentMp: 0
   currentStamina: 100
@@ -10134,6 +10135,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 128
   player: {fileID: 637873415}
+  DrainStaminaAmount: 10
 --- !u!135 &2114479526
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Workers/DEV/YSH/Scripts/DrainManager.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/DrainManager.cs
@@ -18,6 +18,8 @@ public class DrainManager : MonoBehaviour
     public PlayerController Player => player;
     public float DrainSpeed => drainSpeed;
 
+    public float DrainStaminaAmount;
+
     private void Awake()
     {
         col = GetComponent<SphereCollider>();
@@ -35,7 +37,7 @@ public class DrainManager : MonoBehaviour
     IEnumerator DrainRoutine()
     {
         col.radius = minRadius;
-        // Äİ¶óÀÌ´õ¸¦ ¿øÁ¡À¸·Î ÀÌµ¿
+        // ì½œë¼ì´ë”ë¥¼ ì›ì ìœ¼ë¡œ ì´ë™
         transform.localPosition = Vector3.zero;
         while (true)
         {
@@ -55,8 +57,8 @@ public class DrainManager : MonoBehaviour
 
     public void StopDrain()
     {
-        // Äİ¶óÀÌ´õ¸¦ °ÔÀÓ ¿µ¿ª ¿Ü·Î º¸³»¹ö¸°´Ù.
-        // ºñÈ°¼ºÈ­ ÇÏ´Â°ÍÀ¸·Î´Â Exit È£ÃâÀÌ ¾ÈµÇ¹Ç·Î ¹°¸®ÀûÀ¸·Î ¹ş¾î³ª°Ô ÇÏ±â À§ÇÔ
+        // ì½œë¼ì´ë”ë¥¼ ê²Œì„ ì˜ì—­ ì™¸ë¡œ ë³´ë‚´ë²„ë¦°ë‹¤.
+        // ë¹„í™œì„±í™” í•˜ëŠ”ê²ƒìœ¼ë¡œëŠ” Exit í˜¸ì¶œì´ ì•ˆë˜ë¯€ë¡œ ë¬¼ë¦¬ì ìœ¼ë¡œ ë²—ì–´ë‚˜ê²Œ í•˜ê¸° ìœ„í•¨
         transform.localPosition = Vector3.up * 100f;
 
         if (drainRoutine != null)

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -245,6 +245,8 @@ public class PlayerAttack : MonoBehaviour
         tobj.transform.parent = null;
         tobj.transform.position = throwPoint.position;
         tobj.gameObject.SetActive(true);
+        // 최종 데미지 = 타수별 공격력 + (타수별 공격력 * 현재 스탯상 증가량)
+        damage = damage * player.Stat.DefaultPowerPer;
         tobj.SetDamage(damage);
         tobj.Throw(transform.forward + (transform.up * 0.3f), throwForce);
     }
@@ -272,11 +274,9 @@ public class PlayerAttack : MonoBehaviour
             if (damagable == null)
                 continue;
 
-            // 20(타수별 공격력) * 0.1(현재 스탯상 증가량) = 2
-            float damage = MeleeAttackInfo[MeleeCount].Damage * player.Stat.DefaultPowerPer;
-            
-            // 주석 해제 필요
-            //damagable.TakeDamage(damage);
+            // 최종 데미지 = 타수별 공격력 + (타수별 공격력 * 현재 스탯상 증가량)
+            float damage = MeleeAttackInfo[MeleeCount].Damage * player.Stat.DefaultPowerPer;        
+            damagable.TakeDamage(damage);
         }
 
         if (MeleeEffectCount > 0)

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerController.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerController.cs
@@ -7,7 +7,7 @@ using Zenject;
 
 public enum EMachineType { Movement, Attack }
 
-public class PlayerController : MonoBehaviour
+public class PlayerController : MonoBehaviour, IDamagable
 {
     [Inject] private StatModel stat;
 
@@ -76,5 +76,10 @@ public class PlayerController : MonoBehaviour
     public BaseState<PlayerController> GetCurrentState()
     {
         return Fsm.CurrentState;
+    }
+
+    public void TakeDamage(float damage)
+    {
+        Stat.CurrentHp -= damage;
     }
 }

--- a/Assets/Workers/DEV/YSH/Scripts/ThrowObject.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/ThrowObject.cs
@@ -86,8 +86,7 @@ public class ThrowObject : MonoBehaviour, IDrainable
         IDamagable damagable = other.gameObject.GetComponent<IDamagable>();
         if (damagable != null)
         {
-            // 주석 해제 필요
-            //damagable.TakeDamage(damage);
+            damagable.TakeDamage(damage);
         }
 
         Destroy(gameObject);


### PR DESCRIPTION
- StatModel 객체를 통해 플레이어 스탯을 저장하고 계산하여 활용할 수 있도록 함
  - 스테미너의 경우 무한스테미너 구현을 염두하여 수치 계산에 Rate 값을 곱하도록 ChangeStamina 함수를 통해 값을 설정
  - 스탯 설정 시 최대, 최소값 범위 안에서 설정되도록 Clamp 처리
- 플레이어가 TakeDamage를 구현하여 피격 받을 수 있도록 구현
- 점프 Force와 DashTime의 경우 조정되는 능력치는 아니므로 Stat이 아닌 Movement에 배치
- Drain 관련 수치 또한 DrainManager에 별도로 배치
