### PR TITLE
[Feat] 근거리, 원거리 공격 시 마나 회복 구현, 물건 스택 변화 시 이벤트 호출 추가

### DIFF
--- a/Assets/Workers/DEV/KMG/Script/StatModel.cs
+++ b/Assets/Workers/DEV/KMG/Script/StatModel.cs
@@ -43,6 +43,12 @@ public class StatModel : MonoBehaviour
     public float SkillPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.SkillPowerPer))) * 0.01f); private set { } }
     public float ElementalPowerPer { get => 1 + ((AllPowerPer + (GetAbility(AdditionAbility.ElementalPowerPer))) * 0.01f); private set { } }
 
+    public float[] MpAmount = new float[(int)EMpAmountType.Length];
+    public float GetMpGain(EMpAmountType amountType)
+    {
+        return MpAmount[(int)amountType] * (1 + (GetAbility(AdditionAbility.MpGain) * 0.01f));
+    }
+
     [SerializeField] float staminarEgeneration;
     public float StaminarEgeneration { get => staminarEgeneration * (1 + ((GetAbility(AdditionAbility.StaminarEgeneration)) * 0.01f)); private set { } }
 

--- a/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
+++ b/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
@@ -3472,7 +3472,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &709916489
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6531,6 +6531,10 @@ MonoBehaviour:
   maxMp: 100
   moveSpeed: 5
   allPowerPer: 0
+  mpGain: 1
+  MpAmount:
+  - 3
+  - 5
   staminarEgeneration: 10
   DashSpeed: 6.5
   DashStaminaAmount: 0
@@ -8410,8 +8414,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 9044013c5d8549f42969d4de9aee1bee, type: 2}
   - {fileID: 11400000, guid: 77a89bab051376940b3a23c70c211cef, type: 2}
   - {fileID: 11400000, guid: 03cc6dd4b4b96404db1a09065cf2f5d9, type: 2}
-  tempPart: 3
-  tempTier: 3
+  canvas: {fileID: 0}
 --- !u!1 &1749461622
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -27,6 +27,8 @@ public class PlayerAttack : MonoBehaviour
     private Vector3 dest;
     private float resultAngle;
 
+    private EffectGenerator generator;
+
     private Stack<ThrowObject> objectStack;
     public int ObjectCount => objectStack.Count;
 
@@ -42,7 +44,7 @@ public class PlayerAttack : MonoBehaviour
     public int MeleeEffectCount => meleeEffects.Count;
     public float ComboCheckTime => comboCheckTime;
 
-    private EffectGenerator generator;
+    public event UnityAction<int> OnChangedStack; 
 
     private void Awake()
     {
@@ -189,8 +191,8 @@ public class PlayerAttack : MonoBehaviour
         tobj.transform.parent = stackTransform;
         tobj.gameObject.SetActive(false);
 
-        // 이벤트?
-        //Debug.Log($"<color=yellow>Stack Count : {ObjectCount}</color>");
+        // 이벤트
+        OnChangedStack?.Invoke(objectStack.Count);
     }
 
     public ThrowObject PopObjectStack()
@@ -203,8 +205,8 @@ public class PlayerAttack : MonoBehaviour
 
         ThrowObject tobj = objectStack.Pop();
 
-        // 이벤트?
-        //Debug.Log($"<color=yellow>Stack Count : {ObjectCount}</color>");
+        // 이벤트
+        OnChangedStack?.Invoke(objectStack.Count);
 
         return tobj;
     }

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -280,6 +280,9 @@ public class PlayerAttack : MonoBehaviour
             // 최종 데미지 = 타수별 공격력 + (타수별 공격력 * 현재 스탯상 증가량)
             float damage = MeleeAttackInfo[MeleeCount].Damage * player.Stat.DefaultPowerPer;        
             damagable.TakeDamage(damage);
+
+            // Mp 회복
+            player.Stat.CurrentMp += player.Stat.GetMpGain(EMpAmountType.Melee);
         }
 
         if (MeleeEffectCount > 0)

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -31,6 +31,7 @@ public class PlayerAttack : MonoBehaviour
 
     private Stack<ThrowObject> objectStack;
     public int ObjectCount => objectStack.Count;
+    public int MaxObjectCount => maxObjectCount;
 
     public LayerMask WhatIsEnemy { get { return whatIsEnemy; } }
 

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerController.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerController.cs
@@ -7,6 +7,8 @@ using Zenject;
 
 public enum EMachineType { Movement, Attack }
 
+public enum EMpAmountType { Melee, Throw, Length }
+
 public class PlayerController : MonoBehaviour, IDamagable
 {
     [Inject] private StatModel stat;

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/MoveState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/MoveState.cs
@@ -67,7 +67,6 @@ public class MoveState : BaseState<PlayerController>
         base.OnFixedUpdate();
 
         moveDir = owner.PInput.InputDir.normalized;
-        Debug.Log($"<color=lime>MoveSpeed : {owner.Stat.MoveSpeed}</color>");
         owner.Movement.Move(moveDir * owner.Stat.MoveSpeed);
     }
 

--- a/Assets/Workers/DEV/YSH/Scripts/ThrowObject.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/ThrowObject.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Zenject.SpaceFighter;
 
 [RequireComponent(typeof(Rigidbody))]
 public class ThrowObject : MonoBehaviour, IDrainable
@@ -87,6 +88,7 @@ public class ThrowObject : MonoBehaviour, IDrainable
         if (damagable != null)
         {
             damagable.TakeDamage(damage);
+            owner.Stat.CurrentMp += owner.Stat.GetMpGain(EMpAmountType.Throw);
         }
 
         Destroy(gameObject);


### PR DESCRIPTION
- 근거리 및 원거리 공격이 성공 하면 일정량의 마나를 회복한다.
- 물건 획득 및 사용으로 인해 스택이 변화하면 이벤트를 호출하도록 추가 (UI 처리를 위함) 
- 최대 물건 스택 (maxObjectCount)를 외부에서 접근 가능하도록 프로퍼티 추가