### PR TITLE
[Feat] 점프 공격 구현을 위한 상태 추가

### DIFF
--- a/Assets/Workers/DEV/YSH/Prefabs/ThrowObject.prefab
+++ b/Assets/Workers/DEV/YSH/Prefabs/ThrowObject.prefab
@@ -16,7 +16,6 @@ GameObject:
   - component: {fileID: 4766049548964259805}
   - component: {fileID: 4727878797104988335}
   - component: {fileID: 1407591239831133029}
-  - component: {fileID: -2573820941225631044}
   m_Layer: 7
   m_Name: ThrowObject
   m_TagString: Untagged
@@ -186,23 +185,3 @@ MonoBehaviour:
   target: {fileID: 0}
   enable: 0
   name: GuidedFuncion
---- !u!114 &-2573820941225631044
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5993914347992276067}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d074954e16471b54d840b355c42aafc7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  name: ThrowObjectConvertMine
-  enable: 0
-  render: {fileID: 0}
-  meshFilter: {fileID: 0}
-  damage: 0
-  mesh: {fileID: 0}
-  material: {fileID: 0}
-  layer: 

--- a/Assets/Workers/DEV/YSH/Prefabs/ThrowObject.prefab
+++ b/Assets/Workers/DEV/YSH/Prefabs/ThrowObject.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 4766049548964259805}
   - component: {fileID: 4727878797104988335}
   - component: {fileID: 1407591239831133029}
+  - component: {fileID: -2573820941225631044}
   m_Layer: 7
   m_Name: ThrowObject
   m_TagString: Untagged
@@ -169,6 +170,7 @@ MonoBehaviour:
   enable: 0
   name: ThrowObjectUpgrade
   increaseDamage: 1.5
+  IsUpgraded: 0
 --- !u!114 &1407591239831133029
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,3 +186,23 @@ MonoBehaviour:
   target: {fileID: 0}
   enable: 0
   name: GuidedFuncion
+--- !u!114 &-2573820941225631044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5993914347992276067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d074954e16471b54d840b355c42aafc7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  name: ThrowObjectConvertMine
+  enable: 0
+  render: {fileID: 0}
+  meshFilter: {fileID: 0}
+  damage: 0
+  mesh: {fileID: 0}
+  material: {fileID: 0}
+  layer: 

--- a/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
+++ b/Assets/Workers/DEV/YSH/Scenes/YSH_Player.unity
@@ -3302,8 +3302,7 @@ MonoBehaviour:
   - {fileID: 401840278}
   - {fileID: 774590370}
   isRandom: 0
-  _skills:
-  - {fileID: 11400000, guid: 99bf09bef84d4c14e943330fcc8639b2, type: 2}
+  _skillList: []
   _handler: {fileID: 0}
 --- !u!114 &654781872
 MonoBehaviour:
@@ -7765,7 +7764,6 @@ MonoBehaviour:
   maxStamina: 100
   maxMp: 100
   moveSpeed: 5
-  allPowerPer: 0
   MpAmount:
   - 3
   - 5
@@ -8162,6 +8160,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 7420254743281234535, guid: 744790fd829edc343bb6392bc0fb0f1a,
+        type: 3}
+      propertyPath: m_Interpolate
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7889668715304265457, guid: 744790fd829edc343bb6392bc0fb0f1a,
         type: 3}

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/FallState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/FallState.cs
@@ -21,8 +21,15 @@ public class FallState : BaseState<PlayerController>
     {
         if (owner.PInput.TryThrow)
         {
-            // 점프 throw로 변경필요
-            owner.ChangeState(EState.Throw);
+            // 점프 원거리 공격
+            owner.ChangeState(EState.JumpThrow);
+            return;
+        }
+
+        if (owner.PInput.TryMelee)
+        {
+            // 점프 근거리 공격
+            owner.ChangeState(EState.JumpMelee);
             return;
         }
 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpMeleeState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpMeleeState.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class JumpMeleeState : BaseState<PlayerController>
+{
+    public JumpMeleeState(PlayerController owner)
+    {
+        this.owner = owner;
+        type = EState.JumpMelee;
+    }
+
+    public override void OnEnter()
+    {
+        base.OnEnter();
+    }
+
+    public override void OnUpdate()
+    {
+        base.OnUpdate();
+    }
+
+    public override void OnFixedUpdate()
+    {
+        base.OnFixedUpdate();
+    }
+}

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpMeleeState.cs.meta
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpMeleeState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b9a1b95bc45c5249a20e7f68612d79a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpState.cs
@@ -31,8 +31,15 @@ public class JumpState : BaseState<PlayerController>
     {
         if (owner.PInput.TryThrow)
         {
-            // jump throw로 변경 필요
-            owner.ChangeState(EState.Throw);
+            // 점프 원거리 공격
+            owner.ChangeState(EState.JumpThrow);
+            return;
+        }
+
+        if (owner.PInput.TryMelee)
+        {
+            // 점프 근거리 공격
+            owner.ChangeState(EState.JumpMelee);
             return;
         }
 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpThrowState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpThrowState.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class JumpThrowState : BaseState<PlayerController>
+{
+    public JumpThrowState(PlayerController owner)
+    {
+        this.owner = owner;
+        type = EState.JumpThrow;
+    }
+
+    public override void OnEnter()
+    {
+        base.OnEnter();
+    }
+
+    public override void OnUpdate()
+    {
+        base.OnUpdate();
+    }
+
+    public override void OnFixedUpdate()
+    {
+        base.OnFixedUpdate();
+    }
+}

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpThrowState.cs.meta
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/JumpThrowState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a053c83c2cebc947b6c93df0eed4fbd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/PlayerFSM.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/PlayerFSM.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public enum EState { Idle, Move, Dash, Jump, Fall, Throw, Melee, Drain, Length }
+public enum EState { Idle, Move, Dash, Jump, JumpThrow, JumpMelee, Fall, Throw, Melee, Drain, Length }
 
 public class PlayerFSM
 {
@@ -25,6 +25,8 @@ public class PlayerFSM
         States[(int)EState.Move] = new MoveState(owner);
         States[(int)EState.Dash] = new DashState(owner);
         States[(int)EState.Jump] = new JumpState(owner);
+        States[(int)EState.JumpThrow] = new JumpThrowState(owner);
+        States[(int)EState.JumpMelee] = new JumpMeleeState(owner);
         States[(int)EState.Fall] = new FallState(owner);
         States[(int)EState.Throw] = new ThrowState(owner);
         States[(int)EState.Melee] = new MeleeState(owner);


### PR DESCRIPTION
- 점프 원거리 공격 상태인 JumpThrowState 추가
- 점프 근거리 공격 상태인 JumpMeleeState 추가
- 점프 중 공격 입력 시 일치하는 상태로 전이하도록 변경
  - 세부적인 처리 구현 필요 (Exit 조건 및 공격 로직 구현) 