### PR TITLE
[Fix] 조작감 개선, 대쉬 조건 변경, 스테미너 리젠 수정

### DIFF
--- a/Assets/Workers/DEV/IJY/Script/Stamina.cs
+++ b/Assets/Workers/DEV/IJY/Script/Stamina.cs
@@ -12,6 +12,8 @@ public class Stamina : MonoBehaviour
     [SerializeField] public bool IsGetPostion; // 추후 스테미나 회복 포션 획득 시 활성화 예정
     [Inject][SerializeField] private StatModel stat;
     [SerializeField] public Image gauge_Stamina;
+    [SerializeField] private float regenWaitTime; // 스테미너 사용 직후 리젠 대기 시간
+    [SerializeField] private float exhaustionWaitTime; // 스테미너 모두 소진 후 리젠 대기 시간
 
     private void Start()
     {
@@ -31,7 +33,7 @@ public class Stamina : MonoBehaviour
         if (lastStamina < _lastStamina)
         {
             _IsChangeStam = true;
-            _waitTime = 1f;
+            _waitTime = regenWaitTime;
         }
         _lastStamina = lastStamina;
         gauge_Stamina.fillAmount = (stat.MaxStamina - (stat.MaxStamina - _lastStamina)) / stat.MaxStamina;
@@ -44,7 +46,7 @@ public class Stamina : MonoBehaviour
         {
             if (stat.CurrentStamina <= 0.0f && _IsChangeStam == true)
             {
-                _waitTime = 3.0f;
+                _waitTime = exhaustionWaitTime;
                 _IsChangeStam = false;
             }
             if (_waitTime > 0.0f)

--- a/Assets/Workers/DEV/YSH/PlayerAnimController.controller
+++ b/Assets/Workers/DEV/YSH/PlayerAnimController.controller
@@ -398,7 +398,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Throw2
-  m_Speed: 1
+  m_Speed: 1.3
   m_CycleOffset: 0
   m_Transitions: []
   m_StateMachineBehaviours: []
@@ -425,7 +425,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Throw3_Basic
-  m_Speed: 1
+  m_Speed: 1.3
   m_CycleOffset: 0
   m_Transitions: []
   m_StateMachineBehaviours: []
@@ -890,7 +890,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Throw1
-  m_Speed: 1
+  m_Speed: 1.3
   m_CycleOffset: 0
   m_Transitions: []
   m_StateMachineBehaviours: []

--- a/Assets/Workers/DEV/YSH/Prefabs/Player.prefab
+++ b/Assets/Workers/DEV/YSH/Prefabs/Player.prefab
@@ -7797,6 +7797,7 @@ MonoBehaviour:
   maxObjectCount: 50
   comboCheckTime: 0.2
   CanUseCombo: 0
+  CanMoveWhileAttack: 0
 --- !u!54 &7420254743281234535
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -7868,6 +7869,8 @@ MonoBehaviour:
   IsGetPostion: 0
   stat: {fileID: 0}
   gauge_Stamina: {fileID: 7873174449751312792}
+  regenWaitTime: 0.3
+  exhaustionWaitTime: 1
 --- !u!114 &7876092388261278334
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Workers/DEV/YSH/Scenes/YSH_Trap.unity
+++ b/Assets/Workers/DEV/YSH/Scenes/YSH_Trap.unity
@@ -599,6 +599,74 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 57265609}
   m_CullTransparentMesh: 1
+--- !u!1001 &59898311
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2271362963844949128, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_Name
+      value: ObjectBuff (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.333333
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.835
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6f03b6d5d451c3448f96fb49bfe93a3, type: 3}
 --- !u!1 &65777190
 GameObject:
   m_ObjectHideFlags: 0
@@ -7372,6 +7440,74 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &956310107
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2271362963844949128, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_Name
+      value: ObjectBuff (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.6666665
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.835
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6f03b6d5d451c3448f96fb49bfe93a3, type: 3}
 --- !u!1001 &964945101
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9035,6 +9171,74 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1217881504}
   m_CullTransparentMesh: 1
+--- !u!1001 &1251883904
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2271362963844949128, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_Name
+      value: ObjectBuff (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.835
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6f03b6d5d451c3448f96fb49bfe93a3, type: 3}
 --- !u!1 &1264482660
 GameObject:
   m_ObjectHideFlags: 0
@@ -10381,6 +10585,74 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 28}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1001 &1448472107
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2271362963844949128, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_Name
+      value: ObjectBuff
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.835
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6f03b6d5d451c3448f96fb49bfe93a3, type: 3}
 --- !u!1001 &1450278430
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10640,6 +10912,74 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 28}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1001 &1498807191
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2271362963844949128, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_Name
+      value: ObjectBuff (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.835
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6f03b6d5d451c3448f96fb49bfe93a3, type: 3}
 --- !u!1 &1532473670
 GameObject:
   m_ObjectHideFlags: 0
@@ -11662,6 +12002,74 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+--- !u!1001 &1647089926
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2271362963844949128, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_Name
+      value: ObjectBuff (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.3333333
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.835
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6f03b6d5d451c3448f96fb49bfe93a3, type: 3}
 --- !u!1 &1647573926
 GameObject:
   m_ObjectHideFlags: 0
@@ -13085,6 +13493,74 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_IsOn: 1
+--- !u!1001 &1853823813
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2271362963844949128, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_Name
+      value: ObjectBuff (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.6666666
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.835
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913268131066302594, guid: a6f03b6d5d451c3448f96fb49bfe93a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6f03b6d5d451c3448f96fb49bfe93a3, type: 3}
 --- !u!1 &1859959483
 GameObject:
   m_ObjectHideFlags: 0
@@ -15630,3 +16106,10 @@ SceneRoots:
   - {fileID: 929419837}
   - {fileID: 8838911251978849488}
   - {fileID: 2824890675234935036}
+  - {fileID: 1448472107}
+  - {fileID: 1853823813}
+  - {fileID: 1647089926}
+  - {fileID: 1498807191}
+  - {fileID: 956310107}
+  - {fileID: 59898311}
+  - {fileID: 1251883904}

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -71,6 +71,7 @@ public class PlayerAttack : MonoBehaviour
     public float ComboCheckTime => comboCheckTime;
 
     public bool CanUseCombo;
+    public bool CanMoveWhileAttack;
 
     public event UnityAction OnChangedStack;
 
@@ -446,6 +447,7 @@ public class PlayerAttack : MonoBehaviour
     {
         // 콤보가 불가능하도록 flag set
         CanUseCombo = false;
+        CanMoveWhileAttack = true;
     }
     #endregion
 

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -447,6 +447,11 @@ public class PlayerAttack : MonoBehaviour
     {
         // 콤보가 불가능하도록 flag set
         CanUseCombo = false;
+    }
+
+    public void CanMove()
+    {
+        // 공격 중 이동 가능하도록 flag set
         CanMoveWhileAttack = true;
     }
     #endregion

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerController.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerController.cs
@@ -270,11 +270,12 @@ public class PlayerController : MonoBehaviour, IDamagable
         yield break;
     }
 
-    // 추후 StatModel로 옮기는게 좋을 듯
     public bool IsEnoughStamina(float amount)
     {
         Debug.Log($"<color=cyan>Current Stamina : {stat.CurrentStamina}, Amount : {amount}</color>");
-        return stat.CurrentStamina >= amount;
+        //return stat.CurrentStamina >= amount;
+        // 조건 변경 (스테미너가 1이라도 존재한다면 사용 가능)
+        return stat.CurrentStamina > 0;
     }
 
     public float GetCurrentAnimTime(int layer = 0)

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
@@ -17,6 +17,8 @@ public class ThrowState : BaseState<PlayerController>
 
     private Vector3 lookDir;
 
+    private bool wasPressedCombo;
+
     public ThrowState(PlayerController owner)
     {
         this.owner = owner;
@@ -56,6 +58,8 @@ public class ThrowState : BaseState<PlayerController>
 
         // Attack 시작 시에는 콤보 진행 불가능하도록 set
         owner.Attack.CanUseCombo = false;
+        // 버퍼로 사용할 변수
+        wasPressedCombo = false;
         // 공격 시작시에는 움직이지 못하도록 set
         owner.Attack.CanMoveWhileAttack = false;
 
@@ -151,6 +155,15 @@ public class ThrowState : BaseState<PlayerController>
             return;
         }
 
+        // EndCombo 시점에 콤보 입력 버퍼가 확인된 경우
+        if (!owner.Attack.CanUseCombo && wasPressedCombo)
+        {
+            // 애니메이션이 끝나기 전에 전이하므로 카운트를 수동으로 증가
+            owner.Attack.ThrowCount++;
+            OnEnter();
+            return;
+        }
+
         // 콤보 입력 종료 후 유저가 이동을 입력한 경우 이동으로 캔슬
         if (owner.Attack.CanMoveWhileAttack && owner.PInput.InputDir != Vector3.zero)
         {
@@ -164,9 +177,7 @@ public class ThrowState : BaseState<PlayerController>
             && owner.PInput.TryThrow
             && owner.Attack.ObjectCount > 0)
         {
-            // 애니메이션이 끝나기 전에 전이하므로 카운트를 수동으로 증가
-            owner.Attack.ThrowCount++;
-            OnEnter();
+            wasPressedCombo = true;
             return;
         }
 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
@@ -56,6 +56,8 @@ public class ThrowState : BaseState<PlayerController>
 
         // Attack 시작 시에는 콤보 진행 불가능하도록 set
         owner.Attack.CanUseCombo = false;
+        // 공격 시작시에는 움직이지 못하도록 set
+        owner.Attack.CanMoveWhileAttack = false;
 
         // 최초 진입시점 때의 입력값을 기억한다.
         inputDir = owner.PInput.InputDir;
@@ -146,6 +148,13 @@ public class ThrowState : BaseState<PlayerController>
             && owner.IsEnoughStamina(owner.Stat.DashStaminaAmount))
         {
             owner.ChangeState(EState.Dash);
+            return;
+        }
+
+        // 콤보 입력 종료 후 유저가 이동을 입력한 경우 이동으로 캔슬
+        if (owner.Attack.CanMoveWhileAttack && owner.PInput.InputDir != Vector3.zero)
+        {
+            owner.ChangeState(EState.Move);
             return;
         }
 

--- a/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/State/Player/ThrowState.cs
@@ -160,6 +160,11 @@ public class ThrowState : BaseState<PlayerController>
         {
             // 애니메이션이 끝나기 전에 전이하므로 카운트를 수동으로 증가
             owner.Attack.ThrowCount++;
+
+            // 마지막 공격이후라면 콤보 초기화
+            if (owner.Attack.ThrowCount >= owner.Attack.ThrowCountMax)
+                owner.Attack.ThrowCount = 0;
+
             OnEnter();
             return;
         }


### PR DESCRIPTION
- 원거리 공격 1~2타와 중립3타의 애니메이션 속도를 높임
- 원거리 공격 1~2타 사이의 콤보 입력시간을 여유롭게 수정
- 애니메이션이 전부 재생되지 않아도 움직일 수 있도록 수정
- 유저가 공격을 선 입력해도 콤보가 원활하게 이어지도록 수정
- 원거리 3타 중립, 수평 공격 시에도 첫번째 콤보로 선입력 가능하도록 수정
- 스테미너가 1이라도 남아있으면 대쉬 사용 가능하도록 수정
- 인스펙터에서 스테미너 사용 후 리젠 대기시간과 스테미너 전부 소진 후 리젠 대기시간 설정 가능하도록 수정