### PR TITLE
[Fix] 타이틀 씬에서 플레이어를 참조하려는 오류 수정

### DIFF
--- a/Assets/Workers/DEV/Common/Chapter1.unity
+++ b/Assets/Workers/DEV/Common/Chapter1.unity
@@ -9385,6 +9385,7 @@ MonoBehaviour:
   - {fileID: 120158052}
   - {fileID: 983519784}
   isActive: 0
+  player: {fileID: 1834352947}
 --- !u!4 &1356297329
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Workers/DEV/Common/Lobby.unity
+++ b/Assets/Workers/DEV/Common/Lobby.unity
@@ -3286,6 +3286,7 @@ MonoBehaviour:
   - {fileID: 2087522438}
   - {fileID: 563007722}
   isActive: 0
+  player: {fileID: 2087522436}
 --- !u!4 &410475277
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Workers/DEV/KYH/Scripts/UI/InputDeviceManager.cs
+++ b/Assets/Workers/DEV/KYH/Scripts/UI/InputDeviceManager.cs
@@ -38,6 +38,7 @@ public class InputDeviceManager : MonoBehaviour
         {
             currentDevice = DeviceType.KeyboardMouse;
             keyboardImage.gameObject.SetActive(true);
+            sideKeyboardImage.gameObject.SetActive(false);
             gamepadImage.gameObject.SetActive(false);
             inputDeviceDropdown.interactable = false;
         }

--- a/Assets/Workers/DEV/KYH/Scripts/UI/PanelManager.cs
+++ b/Assets/Workers/DEV/KYH/Scripts/UI/PanelManager.cs
@@ -10,17 +10,31 @@ public class PanelManager : MonoBehaviour
     [SerializeField] private GameObject[] panels;
     [SerializeField] private bool isActive = false;
 
-    private PlayerController player;
+    [SerializeField] private PlayerController player;
 
-    private void Start()
+    private void OnEnable()
     {
-        if (SceneManager.GetActiveScene().name == "Title")
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (scene.name == "Title")
         {
             player = null;
         }
         else
         {
             player = FindAnyObjectByType<PlayerController>();
+            if (player == null)
+            {
+                Debug.LogWarning("PlayerController가 없당!");
+            }
         }
     }
 
@@ -29,6 +43,12 @@ public class PanelManager : MonoBehaviour
         isActive = CheckActivePanel();
 
         if (SceneManager.GetActiveScene().name == "Title") return;
+
+        if (player == null)
+        {
+            Debug.LogError("PlayerController가 초기화되지 않았습니다.");
+            return;
+        }
 
         if (isActive)
         {
@@ -55,12 +75,18 @@ public class PanelManager : MonoBehaviour
         {
             if (panel.activeSelf)
             {
-                player.PInput.IsCanControl = false;
+                // 타이틀 씬에서는 player가 null이므로 IsCanControl 설정을 건너뜀
+                if (SceneManager.GetActiveScene().name != "Title" && player != null)
+                {
+                    player.PInput.IsCanControl = false;
+                }
+
                 Time.timeScale = 0;
                 return true;
             }
         }
 
+        // 패널이 모두 비활성화된 경우
         if (SceneManager.GetActiveScene().name == "Title")
         {
             Time.timeScale = 1;
@@ -68,7 +94,11 @@ public class PanelManager : MonoBehaviour
         }
         else
         {
-            player.PInput.IsCanControl = true;
+            // player가 null일 경우를 방어
+            if (player != null)
+            {
+                player.PInput.IsCanControl = true;
+            }
             Time.timeScale = 1;
             return false;
         }


### PR DESCRIPTION
## [수정한 내용]
- PanelManager에서 타이틀 씬에서도 플레이어를 참조하려는 예외처리가 빠진 문제 수정
- 설정창에서 입력기기 선택 드롭다운이 셀렉트 될 때 뒤로가기 이미지가 2개 출력되는 문제 수정