### PR TITLE
[Fix] 돌발 퀘스트 카운팅이 제대로 되지않는 문제 수정

### DIFF
--- a/Assets/Workers/DEV/IJY/Script/_Interactioners/UNQuest_Interaction.cs
+++ b/Assets/Workers/DEV/IJY/Script/_Interactioners/UNQuest_Interaction.cs
@@ -5,7 +5,6 @@ public class UNQuest_Interaction : InteractionOBJ_Base, Interaction_Ibase_Activa
 {
     [SerializeField] private PlayerController player;
     private QuestManager questManager;
-    public UnityAction OnChangeQuestUI;
     public int CurCount { get { return curCount; } set { curCount = value; } }
 
     [Header("돌발 퀘스트 NPC")]
@@ -14,13 +13,12 @@ public class UNQuest_Interaction : InteractionOBJ_Base, Interaction_Ibase_Activa
     [SerializeField] bool isOngoing;
     [SerializeField] int Reward;
 
+    public bool IsOngoing { get { return isOngoing; } }
 
     void Start() => Init();
 
     void Init()
     {
-        OnChangeQuestUI += OnChangeCount;
-
         player = FindObjectOfType<PlayerController>();
         questManager = FindObjectOfType<QuestManager>();
         QuestCount = Random.Range(5, 10);
@@ -91,8 +89,12 @@ public class UNQuest_Interaction : InteractionOBJ_Base, Interaction_Ibase_Activa
         this.gameObject.SetActive(false);
     }
 
-    private void OnChangeCount()
+    public void OnChangeCount()
     {
+        // 퀘스트가 진행중이 아니면 호출되도 아무것도 하지않음
+        if (!isOngoing)
+            return;
+
         if (curCount >= QuestCount) curCount = QuestCount;
         else curCount++;
 
@@ -102,6 +104,5 @@ public class UNQuest_Interaction : InteractionOBJ_Base, Interaction_Ibase_Activa
     void OnDisable()
     {
         isOngoing = false;
-        OnChangeQuestUI -= OnChangeCount;
     }
 }

--- a/Assets/Workers/DEV/YTH/Scripts/DungeonGenerator/MapGenerator.cs
+++ b/Assets/Workers/DEV/YTH/Scripts/DungeonGenerator/MapGenerator.cs
@@ -64,6 +64,8 @@ public class MapGenerator : MonoBehaviour
     [Inject] PlayerController playerController;
     [Inject] InGameSaveData saveData;
 
+    public bool IsNpcExist;
+
     private void Awake()
     {
         chapterManager = GetComponentInChildren<ChapterManager>();
@@ -97,6 +99,11 @@ public class MapGenerator : MonoBehaviour
         if (Util.IsRandom(50))
         {
             Instantiate(NPCPrefab, createPos + Vector3.forward * 10f, Quaternion.identity, transform);
+            IsNpcExist = true;
+        }
+        else
+        {
+            IsNpcExist = false;
         }
 
         // 절차적 맵 생성 시작

--- a/Assets/Workers/DEV/YTH/Scripts/Spawner/MonsterSpawner.cs
+++ b/Assets/Workers/DEV/YTH/Scripts/Spawner/MonsterSpawner.cs
@@ -12,6 +12,9 @@ public class MonsterSpawner : MonoBehaviour
     private Transform[] _spawnPoints;
     RoomBehaviour roomBehaviour;
 
+    private MapGenerator _generator;
+    private UNQuest_Interaction _quest;
+
     private void Awake()
     {
         _spawnPoints = GetComponentsInChildren<Transform>().Skip(1).ToArray();
@@ -20,11 +23,18 @@ public class MonsterSpawner : MonoBehaviour
 
     private void Start()
     {
+        _generator = FindAnyObjectByType<MapGenerator>();
         _monsterPool = FindAnyObjectByType<ObjectPool>();
     }
 
     public void Spawn()
     {
+        // 참조가 없는 경우 한번만 찾는다
+        if (_generator.IsNpcExist && _quest == null)
+        {
+            _quest = FindAnyObjectByType<UNQuest_Interaction>();
+        }
+
         int temp = 0;
         for (int i = 0; i < monsterSpwanInfos.Count; i++)
         {
@@ -33,6 +43,12 @@ public class MonsterSpawner : MonoBehaviour
                 PooledObject pooledObject = _monsterPool.CreateMonster(monsterSpwanInfos[i].monsterName, _spawnPoints[temp++ % _spawnPoints.Length]);
 
                 pooledObject.OnDie += roomBehaviour.MonsterCountChange;
+
+                // quest가 진행중이라면
+                if (_generator.IsNpcExist && _quest.IsOngoing)
+                {
+                    pooledObject.OnDie += _quest.OnChangeCount;
+                }
             }
         }
         roomBehaviour.MonsterCount = temp;

--- a/Assets/Workers/DEV/YTH/Scripts/Spawner/PooledObject.cs
+++ b/Assets/Workers/DEV/YTH/Scripts/Spawner/PooledObject.cs
@@ -119,8 +119,6 @@ public class PooledObject : MonoBehaviour, IKnockBack, IDamagable
     {
         OnDie?.Invoke();    
 
-        player.interactioner.quest_Interaction?.OnChangeQuestUI?.Invoke(); 
-
         _monsterData.IsDead = true;
         _animator.SetBool("IsDead", true);
 


### PR DESCRIPTION
- 몬스터 사망 시 UNQuest_Interaction의 이벤트를 Invoke 하도록 되어 있어 UNQuest_Interaction의 OnChangeCount 함수를 
몬스터 사망 이벤트에 구독 시키도록 수정