### PR TITLE
[Set] 보스몬스터 체력바 프리팹 크기 조절

### DIFF
--- a/Assets/Workers/DEV/KYH/Prefabs/MonsterHPGauge.prefab
+++ b/Assets/Workers/DEV/KYH/Prefabs/MonsterHPGauge.prefab
@@ -273,7 +273,7 @@ RectTransform:
   m_GameObject: {fileID: 5769577991745748242}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.6, y: 0.6, z: 0.6}
+  m_LocalScale: {x: 0.55, y: 0.55, z: 0.55}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 6135540819748886620}
@@ -283,7 +283,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: -293, y: 64}
+  m_AnchoredPosition: {x: -268, y: 66}
   m_SizeDelta: {x: 976, y: 59}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4478569580274203573


### PR DESCRIPTION
보스몬스터 체력바 프리팹이 가방 스킬 UI에 가려지는 문제가 있어 크기를 축소했습니다.