### PR TITLE
[Fix] 스테이지 이동 시 ThrowObject의 Owner가 null이 되는 문제 수정

### DIFF
--- a/Assets/Workers/DEV/KMG/Script/ThrowObjectStack.cs
+++ b/Assets/Workers/DEV/KMG/Script/ThrowObjectStack.cs
@@ -27,4 +27,13 @@ public class ThrowObjectStack : MonoBehaviour
         }
         objectStack.Clear();
     }
+
+    // ThrowObject의 Owner가 씬이 이동하면 파괴되므로 게임이 시작할 때마다 재설정 하기 위한 함수
+    public void SetOwner(PlayerController owner)
+    {
+        foreach (ThrowObject tobj in objectStack)
+        {
+            tobj.Owner = owner;
+        }
+    }
 }

--- a/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/PlayerAttack.cs
@@ -96,6 +96,9 @@ public class PlayerAttack : MonoBehaviour
     private void Start()
     {
         mainCamTrf = Camera.main.transform;
+
+        // 씬이 이동되면 ThrowObject가 저장했던 owner가 null이 되므로 재설정해준다.
+        objectStack.SetOwner(player);
     }
 
     public void GenerateThrowEffects()

--- a/Assets/Workers/DEV/YSH/Scripts/ThrowObject.cs
+++ b/Assets/Workers/DEV/YSH/Scripts/ThrowObject.cs
@@ -15,6 +15,7 @@ public class ThrowObject : MonoBehaviour, IDrainable
     [SerializeField] private bool isCollected;
     private Rigidbody rigid;
     private PlayerController owner;
+    public PlayerController Owner { get { return owner; } set { owner = value; } }
 
     private float damage;
 


### PR DESCRIPTION
- 씬 이동시 Stack에 보관중인 ThrowObject들의 Owner가 null이 되므로 씬이 시작할 때 현재 씬에 있는 Player를 owner로 재설정하도록 처리