### PR TITLE
[Fix] UI/스킬 수정

### DIFF
--- a/Assets/Workers/DEV/HJS/Scripts/Skills/Mana/BlackHollObject.cs
+++ b/Assets/Workers/DEV/HJS/Scripts/Skills/Mana/BlackHollObject.cs
@@ -158,11 +158,7 @@ public class BlackHollObject : MonoBehaviour
         // 기존 상시 효과음을 제거하고
         SoundManager.StopSFX();
 
-        foreach (var enemy in enemies)
-        {
-            if (enemy is null) continue;
-            SetPut(enemy);
-        }
+        
 
         Collider[] colliders = Physics.OverlapSphere(transform.position, explosionRange, LayerMask.GetMask("Monster"));
         foreach (Collider collider in colliders)
@@ -177,6 +173,12 @@ public class BlackHollObject : MonoBehaviour
 
     private void OnDestroy()
     {
+        foreach (var enemy in enemies)
+        {
+            if (enemy is null) continue;
+            SetPut(enemy);
+        }
+
         SoundManager.StopSFX();
         if(isThrow) SoundManager.PlaySFX(SoundManager.SoundData_S.ManaSkillSounds_4[3].AudioClip);
         StopAllCoroutines();

--- a/Assets/Workers/DEV/KYH/Prefabs/MonsterHPGauge.prefab
+++ b/Assets/Workers/DEV/KYH/Prefabs/MonsterHPGauge.prefab
@@ -283,7 +283,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: -268, y: 66}
+  m_AnchoredPosition: {x: -116, y: 154}
   m_SizeDelta: {x: 976, y: 59}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4478569580274203573

--- a/Assets/Workers/DEV/YSH/Prefabs/Player.prefab
+++ b/Assets/Workers/DEV/YSH/Prefabs/Player.prefab
@@ -10022,17 +10022,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 783803244795965005}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: -0.38268343, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.074999996, y: 0.099999994, z: 0.099999994}
-  m_ConstrainProportionsScale: 1
+  m_LocalScale: {x: 0.065, y: 0.099999994, z: 0.099999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6954000642596514752}
   m_Father: {fileID: 1129082954657855962}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -45}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 58.5, y: -26.5}
+  m_AnchoredPosition: {x: 40, y: -25}
   m_SizeDelta: {x: 204, y: 470}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3690543968753749186
@@ -10098,17 +10098,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 840165362542935046}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: -0.38268343, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.074999996, y: 0.099999994, z: 0.099999994}
-  m_ConstrainProportionsScale: 1
+  m_LocalScale: {x: 0.065, y: 0.099999994, z: 0.099999994}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1954642838418981956}
   m_Father: {fileID: 4466315976236938838}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -45}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 58.5, y: -26.5}
+  m_AnchoredPosition: {x: 40, y: -25}
   m_SizeDelta: {x: 204, y: 470}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1058236691534566453
@@ -10433,7 +10433,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 250, y: 140}
+  m_AnchoredPosition: {x: 185, y: 150}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9183386256123412729
@@ -17910,7 +17910,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 150, y: 400}
+  m_AnchoredPosition: {x: 150, y: 390}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &371529938679976416


### PR DESCRIPTION
- 마나스킬 4번 시전 중 폭발 전 이동하여 스킬을 취소했을 때, 끌려 온 몬스터가 동작하지 않던 문제를 수정했습니다.
- 가방 스킬 UI를 조정하여 보스 체력바에 가리지 않도록 수정했습니다.